### PR TITLE
Add context information into input runes

### DIFF
--- a/input.go
+++ b/input.go
@@ -8,7 +8,16 @@ import (
 
 type Input interface {
 	// Text returns the characters to be shaped.
-	Text() []rune
+	//
+	// `itemOffset` is the position of the first character from `text` that will be shaped, and
+	// `itemLength` is the number of character to shape (-1 means the end of the slice).
+	//
+	// When shaping part of a larger text (e.g. a run of text from a paragraph),
+	// instead of passing just the substring corresponding to the run, it is preferable to pass the whole
+	// paragraph and specify the run start and length as `itemOffset` and
+	// `itemLength`, respectively, to give the shaper the full context to be able,
+	// for example, to do cross-run Arabic shaping or properly handle combining marks at start of run.
+	Text() (text []rune, itemOffset, itemLength int)
 	// Direction returns the directionality of the text.
 	Direction() di.Direction
 	// Face returns the font face to render the text in.

--- a/input.go
+++ b/input.go
@@ -7,17 +7,13 @@ import (
 )
 
 type Input interface {
-	// Text returns the characters to be shaped.
+	// Text returns the characters to be shaped, which is `text[start:end]`.
 	//
-	// `itemOffset` is the position of the first character from `text` that will be shaped, and
-	// `itemLength` is the number of character to shape (-1 means the end of the slice).
-	//
-	// When shaping part of a larger text (e.g. a run of text from a paragraph),
+	// When shaping part of a larger text (e.g. a run of text from a line),
 	// instead of passing just the substring corresponding to the run, it is preferable to pass the whole
-	// paragraph and specify the run start and length as `itemOffset` and
-	// `itemLength`, respectively, to give the shaper the full context to be able,
+	// line and specify the run `start` and `end` to give the shaper the full context to be able,
 	// for example, to do cross-run Arabic shaping or properly handle combining marks at start of run.
-	Text() (text []rune, itemOffset, itemLength int)
+	Text() (text []rune, start, end int)
 	// Direction returns the directionality of the text.
 	Direction() di.Direction
 	// Face returns the font face to render the text in.


### PR DESCRIPTION
This PR adresses one of the remaining items from #1, by supporting start index and length so that the shaper can access surrounding context.


