### PR TITLE
shaping: count runes and glyphs in clusters

### DIFF
--- a/output.go
+++ b/output.go
@@ -24,16 +24,16 @@ type Glyph struct {
 	YOffset  fixed.Int26_6
 	// Cluster is the lowest rune index of all runes shaped into
 	// this glyph cluster. All glyphs sharing the same cluster value
-	// are part of the same cluster and will have identical NumRunes
-	// and NumGlyphs fields.
+	// are part of the same cluster and will have identical RuneCount
+	// and GlyphCount fields.
 	Cluster int
-	// NumRunes is the number of input runes shaped into this output
+	// RuneCount is the number of input runes shaped into this output
 	// glyph cluster.
-	NumRunes int
-	// NumGlyphs is the number of glyphs in this output glyph cluster.
-	NumGlyphs int
-	Glyph     fonts.GID
-	Mask      harfbuzz.GlyphMask
+	RuneCount int
+	// GlyphCount is the number of glyphs in this output glyph cluster.
+	GlyphCount int
+	Glyph      fonts.GID
+	Mask       harfbuzz.GlyphMask
 }
 
 // LeftSideBearing returns the distance from the glyph's X origin to

--- a/output.go
+++ b/output.go
@@ -22,9 +22,18 @@ type Glyph struct {
 	YAdvance fixed.Int26_6
 	XOffset  fixed.Int26_6
 	YOffset  fixed.Int26_6
-	Cluster  int
-	Glyph    fonts.GID
-	Mask     harfbuzz.GlyphMask
+	// Cluster is the lowest rune index of all runes shaped into
+	// this glyph cluster. All glyphs sharing the same cluster value
+	// are part of the same cluster and will have identical NumRunes
+	// and NumGlyphs fields.
+	Cluster int
+	// NumRunes is the number of input runes shaped into this output
+	// glyph cluster.
+	NumRunes int
+	// NumGlyphs is the number of glyphs in this output glyph cluster.
+	NumGlyphs int
+	Glyph     fonts.GID
+	Mask      harfbuzz.GlyphMask
 }
 
 // LeftSideBearing returns the distance from the glyph's X origin to

--- a/output.go
+++ b/output.go
@@ -22,17 +22,17 @@ type Glyph struct {
 	YAdvance fixed.Int26_6
 	XOffset  fixed.Int26_6
 	YOffset  fixed.Int26_6
-	// Cluster is the lowest rune index of all runes shaped into
+	// ClusterIndex is the lowest rune index of all runes shaped into
 	// this glyph cluster. All glyphs sharing the same cluster value
 	// are part of the same cluster and will have identical RuneCount
 	// and GlyphCount fields.
-	Cluster int
+	ClusterIndex int
 	// RuneCount is the number of input runes shaped into this output
 	// glyph cluster.
 	RuneCount int
 	// GlyphCount is the number of glyphs in this output glyph cluster.
 	GlyphCount int
-	Glyph      fonts.GID
+	GlyphID    fonts.GID
 	Mask       harfbuzz.GlyphMask
 }
 

--- a/output_test.go
+++ b/output_test.go
@@ -29,7 +29,7 @@ var (
 		Gap:     fixed.I(int(0)),
 	}
 	simpleGlyph = shaping.Glyph{
-		Glyph:    simpleGID,
+		GlyphID:    simpleGID,
 		XAdvance: fixed.I(int(10)),
 		YAdvance: fixed.I(int(10)),
 		XOffset:  fixed.I(int(0)),
@@ -39,7 +39,7 @@ var (
 		YBearing: fixed.I(int(10)),
 	}
 	leftExtentGlyph = shaping.Glyph{
-		Glyph:    leftExtentGID,
+		GlyphID:    leftExtentGID,
 		XAdvance: fixed.I(int(5)),
 		YAdvance: fixed.I(int(5)),
 		XOffset:  fixed.I(int(0)),
@@ -50,7 +50,7 @@ var (
 		XBearing: fixed.I(int(5)),
 	}
 	rightExtentGlyph = shaping.Glyph{
-		Glyph:    rightExtentGID,
+		GlyphID:    rightExtentGID,
 		XAdvance: fixed.I(int(5)),
 		YAdvance: fixed.I(int(5)),
 		XOffset:  fixed.I(int(0)),
@@ -61,7 +61,7 @@ var (
 		XBearing: fixed.I(int(0)),
 	}
 	deepGlyph = shaping.Glyph{
-		Glyph:    deepGID,
+		GlyphID:    deepGID,
 		XAdvance: fixed.I(int(10)),
 		YAdvance: fixed.I(int(10)),
 		XOffset:  fixed.I(int(0)),
@@ -72,7 +72,7 @@ var (
 		XBearing: fixed.I(int(0)),
 	}
 	offsetGlyph = shaping.Glyph{
-		Glyph:    offsetGID,
+		GlyphID:    offsetGID,
 		XAdvance: fixed.I(int(10)),
 		YAdvance: fixed.I(int(10)),
 		XOffset:  fixed.I(int(2)),

--- a/shaper.go
+++ b/shaper.go
@@ -150,7 +150,7 @@ func countClusters(glyphs []Glyph, textLen int, dir di.Direction) {
 			}
 			previousCluster = g
 		}
-		glyphs[i].NumGlyphs = glyphsInCluster
-		glyphs[i].NumRunes = runesInCluster
+		glyphs[i].GlyphCount = glyphsInCluster
+		glyphs[i].RuneCount = runesInCluster
 	}
 }

--- a/shaper.go
+++ b/shaper.go
@@ -88,17 +88,17 @@ func Shape(input Input) (Output, error) {
 			return Output{}, MissingGlyphError{GID: g}
 		}
 		glyphs[i] = Glyph{
-			Width:    fixed.I(int(extents.Width)) >> scaleShift,
-			Height:   fixed.I(int(extents.Height)) >> scaleShift,
-			XBearing: fixed.I(int(extents.XBearing)) >> scaleShift,
-			YBearing: fixed.I(int(extents.YBearing)) >> scaleShift,
-			XAdvance: fixed.I(int(buf.Pos[i].XAdvance)) >> scaleShift,
-			YAdvance: fixed.I(int(buf.Pos[i].YAdvance)) >> scaleShift,
-			XOffset:  fixed.I(int(buf.Pos[i].XOffset)) >> scaleShift,
-			YOffset:  fixed.I(int(buf.Pos[i].YOffset)) >> scaleShift,
-			Cluster:  buf.Info[i].Cluster,
-			Glyph:    g,
-			Mask:     buf.Info[i].Mask,
+			Width:        fixed.I(int(extents.Width)) >> scaleShift,
+			Height:       fixed.I(int(extents.Height)) >> scaleShift,
+			XBearing:     fixed.I(int(extents.XBearing)) >> scaleShift,
+			YBearing:     fixed.I(int(extents.YBearing)) >> scaleShift,
+			XAdvance:     fixed.I(int(buf.Pos[i].XAdvance)) >> scaleShift,
+			YAdvance:     fixed.I(int(buf.Pos[i].YAdvance)) >> scaleShift,
+			XOffset:      fixed.I(int(buf.Pos[i].XOffset)) >> scaleShift,
+			YOffset:      fixed.I(int(buf.Pos[i].YOffset)) >> scaleShift,
+			ClusterIndex: buf.Info[i].Cluster,
+			GlyphID:      g,
+			Mask:         buf.Info[i].Mask,
 		}
 	}
 	countClusters(glyphs, input.RunEnd-input.RunStart, input.Direction)
@@ -122,7 +122,7 @@ func countClusters(glyphs []Glyph, textLen int, dir di.Direction) {
 	glyphsInCluster := 0
 	previousCluster := textLen
 	for i := range glyphs {
-		g := glyphs[i].Cluster
+		g := glyphs[i].ClusterIndex
 		if g != currentCluster {
 			// If we're processing a new cluster, count the runes and glyphs
 			// that compose it.
@@ -132,10 +132,10 @@ func countClusters(glyphs []Glyph, textLen int, dir di.Direction) {
 			nextCluster := -1
 		glyphCountLoop:
 			for k := i + 1; k < len(glyphs); k++ {
-				if glyphs[k].Cluster == g {
+				if glyphs[k].ClusterIndex == g {
 					glyphsInCluster++
 				} else {
-					nextCluster = glyphs[k].Cluster
+					nextCluster = glyphs[k].ClusterIndex
 					break glyphCountLoop
 				}
 			}

--- a/shaping_test.go
+++ b/shaping_test.go
@@ -30,52 +30,52 @@ func TestCountClusters(t *testing.T) {
 			// A[4],A[5],A[6],A[7] => G[4],G[5] (reorder, ligature, etc...)
 			glyphs: []Glyph{
 				{
-					Cluster: 0,
+					ClusterIndex: 0,
 				},
 				{
-					Cluster: 1,
+					ClusterIndex: 1,
 				},
 				{
-					Cluster: 3,
+					ClusterIndex: 3,
 				},
 				{
-					Cluster: 3,
+					ClusterIndex: 3,
 				},
 				{
-					Cluster: 4,
+					ClusterIndex: 4,
 				},
 				{
-					Cluster: 4,
+					ClusterIndex: 4,
 				},
 			},
 			expected: []Glyph{
 				{
-					Cluster:    0,
+					ClusterIndex:    0,
 					RuneCount:  1,
 					GlyphCount: 1,
 				},
 				{
-					Cluster:    1,
+					ClusterIndex:    1,
 					RuneCount:  2,
 					GlyphCount: 1,
 				},
 				{
-					Cluster:    3,
+					ClusterIndex:    3,
 					RuneCount:  1,
 					GlyphCount: 2,
 				},
 				{
-					Cluster:    3,
+					ClusterIndex:    3,
 					RuneCount:  1,
 					GlyphCount: 2,
 				},
 				{
-					Cluster:    4,
+					ClusterIndex:    4,
 					RuneCount:  4,
 					GlyphCount: 2,
 				},
 				{
-					Cluster:    4,
+					ClusterIndex:    4,
 					RuneCount:  4,
 					GlyphCount: 2,
 				},
@@ -93,52 +93,52 @@ func TestCountClusters(t *testing.T) {
 			// A[4],A[5],A[6],A[7] => G[0],G[1] (reorder, ligature, etc...)
 			glyphs: []Glyph{
 				{
-					Cluster: 4,
+					ClusterIndex: 4,
 				},
 				{
-					Cluster: 4,
+					ClusterIndex: 4,
 				},
 				{
-					Cluster: 3,
+					ClusterIndex: 3,
 				},
 				{
-					Cluster: 3,
+					ClusterIndex: 3,
 				},
 				{
-					Cluster: 1,
+					ClusterIndex: 1,
 				},
 				{
-					Cluster: 0,
+					ClusterIndex: 0,
 				},
 			},
 			expected: []Glyph{
 				{
-					Cluster:    4,
+					ClusterIndex:    4,
 					RuneCount:  4,
 					GlyphCount: 2,
 				},
 				{
-					Cluster:    4,
+					ClusterIndex:    4,
 					RuneCount:  4,
 					GlyphCount: 2,
 				},
 				{
-					Cluster:    3,
+					ClusterIndex:    3,
 					RuneCount:  1,
 					GlyphCount: 2,
 				},
 				{
-					Cluster:    3,
+					ClusterIndex:    3,
 					RuneCount:  1,
 					GlyphCount: 2,
 				},
 				{
-					Cluster:    1,
+					ClusterIndex:    1,
 					RuneCount:  2,
 					GlyphCount: 1,
 				},
 				{
-					Cluster:    0,
+					ClusterIndex:    0,
 					RuneCount:  1,
 					GlyphCount: 1,
 				},
@@ -150,8 +150,8 @@ func TestCountClusters(t *testing.T) {
 			for i := range tc.glyphs {
 				g := tc.glyphs[i]
 				e := tc.expected[i]
-				if !(g.Cluster == e.Cluster && g.RuneCount == e.RuneCount && g.GlyphCount == e.GlyphCount) {
-					t.Errorf("mismatch on glyph %d: expected cluster %d RuneCount %d GlyphCount %d, got cluster %d RuneCount %d GlyphCount %d", i, e.Cluster, e.RuneCount, e.GlyphCount, g.Cluster, g.RuneCount, g.GlyphCount)
+				if !(g.ClusterIndex == e.ClusterIndex && g.RuneCount == e.RuneCount && g.GlyphCount == e.GlyphCount) {
+					t.Errorf("mismatch on glyph %d: expected cluster %d RuneCount %d GlyphCount %d, got cluster %d RuneCount %d GlyphCount %d", i, e.ClusterIndex, e.RuneCount, e.GlyphCount, g.ClusterIndex, g.RuneCount, g.GlyphCount)
 				}
 			}
 		})

--- a/shaping_test.go
+++ b/shaping_test.go
@@ -1,0 +1,159 @@
+package shaping
+
+import (
+	"testing"
+
+	"github.com/go-text/di"
+)
+
+func TestCountClusters(t *testing.T) {
+	type testcase struct {
+		name     string
+		textLen  int
+		dir      di.Direction
+		glyphs   []Glyph
+		expected []Glyph
+	}
+	for _, tc := range []testcase{
+		{
+			name: "empty",
+		},
+		{
+			name:    "ltr",
+			textLen: 8,
+			dir:     di.DirectionLTR,
+			// Addressing the runes of text as A[0]-A[9] and the glyphs as
+			// G[0]-G[5], this input models the following:
+			// A[0] => G[0]
+			// A[1],A[2] => G[1] (ligature)
+			// A[3] => G[2],G[3] (expansion)
+			// A[4],A[5],A[6],A[7] => G[4],G[5] (reorder, ligature, etc...)
+			glyphs: []Glyph{
+				{
+					Cluster: 0,
+				},
+				{
+					Cluster: 1,
+				},
+				{
+					Cluster: 3,
+				},
+				{
+					Cluster: 3,
+				},
+				{
+					Cluster: 4,
+				},
+				{
+					Cluster: 4,
+				},
+			},
+			expected: []Glyph{
+				{
+					Cluster:   0,
+					NumRunes:  1,
+					NumGlyphs: 1,
+				},
+				{
+					Cluster:   1,
+					NumRunes:  2,
+					NumGlyphs: 1,
+				},
+				{
+					Cluster:   3,
+					NumRunes:  1,
+					NumGlyphs: 2,
+				},
+				{
+					Cluster:   3,
+					NumRunes:  1,
+					NumGlyphs: 2,
+				},
+				{
+					Cluster:   4,
+					NumRunes:  4,
+					NumGlyphs: 2,
+				},
+				{
+					Cluster:   4,
+					NumRunes:  4,
+					NumGlyphs: 2,
+				},
+			},
+		},
+		{
+			name:    "rtl",
+			textLen: 8,
+			dir:     di.DirectionRTL,
+			// Addressing the runes of text as A[0]-A[9] and the glyphs as
+			// G[0]-G[5], this input models the following:
+			// A[0] => G[5]
+			// A[1],A[2] => G[4] (ligature)
+			// A[3] => G[2],G[3] (expansion)
+			// A[4],A[5],A[6],A[7] => G[0],G[1] (reorder, ligature, etc...)
+			glyphs: []Glyph{
+				{
+					Cluster: 4,
+				},
+				{
+					Cluster: 4,
+				},
+				{
+					Cluster: 3,
+				},
+				{
+					Cluster: 3,
+				},
+				{
+					Cluster: 1,
+				},
+				{
+					Cluster: 0,
+				},
+			},
+			expected: []Glyph{
+				{
+					Cluster:   4,
+					NumRunes:  4,
+					NumGlyphs: 2,
+				},
+				{
+					Cluster:   4,
+					NumRunes:  4,
+					NumGlyphs: 2,
+				},
+				{
+					Cluster:   3,
+					NumRunes:  1,
+					NumGlyphs: 2,
+				},
+				{
+					Cluster:   3,
+					NumRunes:  1,
+					NumGlyphs: 2,
+				},
+				{
+					Cluster:   1,
+					NumRunes:  2,
+					NumGlyphs: 1,
+				},
+				{
+					Cluster:   0,
+					NumRunes:  1,
+					NumGlyphs: 1,
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			countClusters(tc.glyphs, tc.textLen, tc.dir)
+			for i := range tc.glyphs {
+				g := tc.glyphs[i]
+				e := tc.expected[i]
+				if !(g.Cluster == e.Cluster && g.NumRunes == e.NumRunes && g.NumGlyphs == e.NumGlyphs) {
+					t.Errorf("mismatch on glyph %d: expected cluster %d numRunes %d numGlyphs %d, got cluster %d numRunes %d numGlyphs %d", i, e.Cluster, e.NumRunes, e.NumGlyphs, g.Cluster, g.NumRunes, g.NumGlyphs)
+				}
+			}
+		})
+	}
+}

--- a/shaping_test.go
+++ b/shaping_test.go
@@ -50,34 +50,34 @@ func TestCountClusters(t *testing.T) {
 			},
 			expected: []Glyph{
 				{
-					Cluster:   0,
-					NumRunes:  1,
-					NumGlyphs: 1,
+					Cluster:    0,
+					RuneCount:  1,
+					GlyphCount: 1,
 				},
 				{
-					Cluster:   1,
-					NumRunes:  2,
-					NumGlyphs: 1,
+					Cluster:    1,
+					RuneCount:  2,
+					GlyphCount: 1,
 				},
 				{
-					Cluster:   3,
-					NumRunes:  1,
-					NumGlyphs: 2,
+					Cluster:    3,
+					RuneCount:  1,
+					GlyphCount: 2,
 				},
 				{
-					Cluster:   3,
-					NumRunes:  1,
-					NumGlyphs: 2,
+					Cluster:    3,
+					RuneCount:  1,
+					GlyphCount: 2,
 				},
 				{
-					Cluster:   4,
-					NumRunes:  4,
-					NumGlyphs: 2,
+					Cluster:    4,
+					RuneCount:  4,
+					GlyphCount: 2,
 				},
 				{
-					Cluster:   4,
-					NumRunes:  4,
-					NumGlyphs: 2,
+					Cluster:    4,
+					RuneCount:  4,
+					GlyphCount: 2,
 				},
 			},
 		},
@@ -113,34 +113,34 @@ func TestCountClusters(t *testing.T) {
 			},
 			expected: []Glyph{
 				{
-					Cluster:   4,
-					NumRunes:  4,
-					NumGlyphs: 2,
+					Cluster:    4,
+					RuneCount:  4,
+					GlyphCount: 2,
 				},
 				{
-					Cluster:   4,
-					NumRunes:  4,
-					NumGlyphs: 2,
+					Cluster:    4,
+					RuneCount:  4,
+					GlyphCount: 2,
 				},
 				{
-					Cluster:   3,
-					NumRunes:  1,
-					NumGlyphs: 2,
+					Cluster:    3,
+					RuneCount:  1,
+					GlyphCount: 2,
 				},
 				{
-					Cluster:   3,
-					NumRunes:  1,
-					NumGlyphs: 2,
+					Cluster:    3,
+					RuneCount:  1,
+					GlyphCount: 2,
 				},
 				{
-					Cluster:   1,
-					NumRunes:  2,
-					NumGlyphs: 1,
+					Cluster:    1,
+					RuneCount:  2,
+					GlyphCount: 1,
 				},
 				{
-					Cluster:   0,
-					NumRunes:  1,
-					NumGlyphs: 1,
+					Cluster:    0,
+					RuneCount:  1,
+					GlyphCount: 1,
 				},
 			},
 		},
@@ -150,8 +150,8 @@ func TestCountClusters(t *testing.T) {
 			for i := range tc.glyphs {
 				g := tc.glyphs[i]
 				e := tc.expected[i]
-				if !(g.Cluster == e.Cluster && g.NumRunes == e.NumRunes && g.NumGlyphs == e.NumGlyphs) {
-					t.Errorf("mismatch on glyph %d: expected cluster %d numRunes %d numGlyphs %d, got cluster %d numRunes %d numGlyphs %d", i, e.Cluster, e.NumRunes, e.NumGlyphs, g.Cluster, g.NumRunes, g.NumGlyphs)
+				if !(g.Cluster == e.Cluster && g.RuneCount == e.RuneCount && g.GlyphCount == e.GlyphCount) {
+					t.Errorf("mismatch on glyph %d: expected cluster %d RuneCount %d GlyphCount %d, got cluster %d RuneCount %d GlyphCount %d", i, e.Cluster, e.RuneCount, e.GlyphCount, g.Cluster, g.RuneCount, g.GlyphCount)
 				}
 			}
 		})


### PR DESCRIPTION
This commit introduces two new fields to the Glyph type.
NumRunes and NumGlyphs tell consuming code how many runes
and glyphs are part of each output cluster, which greatly
simplifies post-shaping text processing tasks.

Fixes #10 